### PR TITLE
Fix edge case that does not properly find targetViewController in iOS15

### DIFF
--- a/Sources/NavigationStatusBarStyling/NavigationStatusBarStyling.swift
+++ b/Sources/NavigationStatusBarStyling/NavigationStatusBarStyling.swift
@@ -1,9 +1,4 @@
-//
-//  NavigationStatusBarStyling.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import UIKit
 

--- a/Sources/NavigationStatusBarStyling/UINavigationController+StatusBarStyling.swift
+++ b/Sources/NavigationStatusBarStyling/UINavigationController+StatusBarStyling.swift
@@ -1,9 +1,4 @@
-//
-//  UINavigationController+StatusBarStyling.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import UIKit
 

--- a/Sources/StatusBarStyling/StatusBarStyleControllable.swift
+++ b/Sources/StatusBarStyling/StatusBarStyleControllable.swift
@@ -1,0 +1,4 @@
+//  Copyright © 2023 PRND. All rights reserved.
+
+///
+public protocol StatusBarStyleControllable: AnyObject { }

--- a/Sources/StatusBarStyling/StatusBarStyling.swift
+++ b/Sources/StatusBarStyling/StatusBarStyling.swift
@@ -1,9 +1,4 @@
-//
-//  StatusBarStylingViewController.swift
-//
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import SwiftUI
 

--- a/Sources/StatusBarStyling/StatusBarStylingView.swift
+++ b/Sources/StatusBarStyling/StatusBarStylingView.swift
@@ -1,9 +1,4 @@
-//
-//  StatusBarStylingView.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import SwiftUI
 

--- a/Sources/StatusBarStyling/StatusBarStylingViewController.swift
+++ b/Sources/StatusBarStyling/StatusBarStylingViewController.swift
@@ -1,14 +1,9 @@
-//
-//  StatusBarStylingViewController.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import UIKit
 
 
-final class StatusBarStylingViewController: UIViewController {
+final class StatusBarStylingViewController: UIViewController, StatusBarStyleControllable {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         statusBarStyle
     }

--- a/Sources/StatusBarStyling/UIHostingController+StatusBarStyling.swift
+++ b/Sources/StatusBarStyling/UIHostingController+StatusBarStyling.swift
@@ -1,9 +1,4 @@
-//
-//  UIHostingController+StatusBarStyling.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import SwiftUI
 
@@ -56,7 +51,7 @@ private extension UIViewController {
     }
     
     func findInChildren() -> UIViewController? {
-        guard let viewController = children.lazy.first(where: { $0 is StatusBarStylingViewController }) else {
+        guard let viewController = children.lazy.first(where: { $0 is StatusBarStyleControllable }) else {
             return children.lazy.compactMap { $0.findStatusBarStylingViewController() }.first
         }
         return viewController
@@ -64,7 +59,7 @@ private extension UIViewController {
     
     var targetController: UIViewController? {
         switch self {
-        case is UINavigationController, is UITabBarController, is StatusBarStylingViewController:
+        case is UINavigationController, is UITabBarController:
             return self
         default:
             return nil

--- a/Sources/StatusBarStyling/View+StatusBarStyling.swift
+++ b/Sources/StatusBarStyling/View+StatusBarStyling.swift
@@ -1,9 +1,4 @@
-//
-//  View+StatusBarStyling.swift
-//  
-//
-//  Created by PRND on 2023/01/12.
-//
+//  Copyright © 2023 PRND. All rights reserved.
 
 import SwiftUI
 


### PR DESCRIPTION
- If View Controller adopts StatusBarStyleControllable when this issue occurs, it can be clearly found inside.
- Occurs when UIHostingViewController and UIViewControllerRepresentable overlap.
- Not reproduced in iOS16 and later.