### PR TITLE
Fix status bar to update even when StatusBarStylingViewController disappears

### DIFF
--- a/Sources/StatusBarStyling/StatusBarStylingViewController.swift
+++ b/Sources/StatusBarStyling/StatusBarStylingViewController.swift
@@ -16,8 +16,8 @@ final class StatusBarStylingViewController: UIViewController, StatusBarStyleCont
         nil
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
         setNeedsStatusBarAppearanceUpdateToTopParent()
     }

--- a/Sources/StatusBarStyling/StatusBarStylingViewController.swift
+++ b/Sources/StatusBarStyling/StatusBarStylingViewController.swift
@@ -16,11 +16,19 @@ final class StatusBarStylingViewController: UIViewController, StatusBarStyleCont
         nil
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         
         setNeedsStatusBarAppearanceUpdateToTopParent()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        topParent?.setNeedsStatusBarAppearanceUpdate()
+    }
+    
+    weak var topParent: UIViewController?
     
     var statusBarStyle: UIStatusBarStyle {
         didSet {
@@ -35,7 +43,10 @@ final class StatusBarStylingViewController: UIViewController, StatusBarStyleCont
     }
     
     func setNeedsStatusBarAppearanceUpdateToTopParent() {
-        topParent().setNeedsStatusBarAppearanceUpdate()
+        let topParent = topParent()
+        guard topParent != self else { return }
+        self.topParent = topParent
+        topParent.setNeedsStatusBarAppearanceUpdate()
     }
     
     required init(statusBarStyle: UIStatusBarStyle, statusBarHidden: Bool) {


### PR DESCRIPTION
This is to ensure that even when a view transition occurs along with animations in a scene of SwiftUI (e.g., view branching in `ZStack`), the status bar is updated when all animations are completed.
- Since the completion of animations coincides with the moment `viewDidDisappear(_:)` is called in `StatusBarStylingViewController`, `StatusBarStylingViewController` fixed to call `setNeedsStatusBarAppearanceUpdate()` using the previously saved top parent.
- If the top parent found in `StatusBarStylingViewController` is `self`, calling `setNeedsStatusBarAppearanceUpdate()` is meaningless, so a `guard` statement has been added.