### PR TITLE
iOS 26부터 status bar 스타일링 코드 비활성화

### DIFF
--- a/Sources/NavigationStatusBarStyling/NavigationStatusBarStyling.swift
+++ b/Sources/NavigationStatusBarStyling/NavigationStatusBarStyling.swift
@@ -8,6 +8,8 @@ import StatusBarStyling
 public enum NavigationStatusBarStyling {
     public static func setup() {
         StatusBarStyling.setup()
+        // iOS 26부터는 시스템이 status bar 색상을 자동으로 처리하므로 스위즐링을 하지 않는다.
+        guard #unavailable(iOS 26.0) else { return }
         UINavigationController.swizzlingForStatusBar()
     }
 }

--- a/Sources/StatusBarStyling/StatusBarStyling.swift
+++ b/Sources/StatusBarStyling/StatusBarStyling.swift
@@ -5,6 +5,8 @@ import SwiftUI
 
 public enum StatusBarStyling {
     public static func setup() {
+        // iOS 26부터는 시스템이 status bar 색상을 자동으로 처리하므로 스위즐링을 하지 않는다.
+        guard #unavailable(iOS 26.0) else { return }
         UIHostingController<AnyView>.swizzlingForStatusBar()
     }
 }

--- a/Sources/StatusBarStyling/View+StatusBarStyling.swift
+++ b/Sources/StatusBarStyling/View+StatusBarStyling.swift
@@ -4,8 +4,14 @@ import SwiftUI
 
 
 extension View {
+    @ViewBuilder
     public func statusBar(style: UIStatusBarStyle, hidden: Bool = false) -> some View {
-        inject(StatusBarStylingView(statusBarStyle: style, statusBarHidden: hidden))
+        // iOS 26부터는 시스템이 status bar 색상을 자동으로 처리하므로 VC를 주입하지 않는다.
+        if #unavailable(iOS 26.0) {
+            inject(StatusBarStylingView(statusBarStyle: style, statusBarHidden: hidden))
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
iOS 26부터는 시스템이 status bar 색상을 자동으로 처리하므로, 이 라이브러리의 스타일링 코드가 **iOS 26 미만에서만** 동작하도록 `#unavailable(iOS 26.0)` 가드를 추가합니다.

- **`StatusBarStyling.setup()`** — `UIHostingController` 스위즐링 차단 (핵심 진입점)
- **`NavigationStatusBarStyling.setup()`** — `UINavigationController` 스위즐링 차단
- **`View.statusBar(style:hidden:)`** — `@ViewBuilder`로 분기, iOS 26+에서는 `self`를 그대로 반환해 불필요한 `StatusBarStylingViewController` 주입을 건너뜀

호출부 코드는 수정 없이 그대로 두어도 iOS 26+에서 자동으로 무력화됩니다. `#unavailable`은 런타임 OS 버전 기준이라 iOS 25 이하 기기에서는 기존과 동일하게 동작합니다.

## Test Coverage
OS 버전 게이팅(`#unavailable(iOS 26.0)`) 동작은 iOS 26 런타임 없이 단위 테스트로 검증하기 어려워 신규 테스트는 추가하지 않았습니다. 대신 두 타겟 모두 빌드 검증을 수행했습니다.

- `xcodebuild -scheme StatusBarStyling -destination 'generic/platform=iOS'` → **BUILD SUCCEEDED**
- `xcodebuild -scheme NavigationStatusBarStyling -destination 'generic/platform=iOS'` → **BUILD SUCCEEDED**

## Pre-Landing Review
작은 diff(12줄)로 specialist 리뷰는 생략. 게이팅 로직 정확, SQL/보안/LLM 무관.

## Adversarial Review
Claude + Codex(gpt-5.5) 교차 리뷰 → **No findings**. 두 `setup()` 진입점과 `View.statusBar` 주입 경로가 모두 게이팅되며, 내부 스위즐 헬퍼/`StatusBarStylingView`는 접근 수준상 클라이언트가 우회할 수 없음을 확인.

## Test plan
- [x] StatusBarStyling 타겟 iOS 빌드 통과
- [x] NavigationStatusBarStyling 타겟 iOS 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)